### PR TITLE
support multi keys mode of MIGRATE command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ perl:
   - "5.12"
   - "5.10"
 env:
+  - REDIS_VERSION=3.2-rc1
   - REDIS_VERSION=3.0.5
   - REDIS_VERSION=2.8.23
 install:

--- a/xt/99_redis_doc.t
+++ b/xt/99_redis_doc.t
@@ -111,11 +111,20 @@ our %before_tests = (
         }
     },
     migrate => sub {
-        my ($host, $port, $key, $db) = @_;
+        my ($host, $port, $key, $db, $timeout, @extra) = @_;
         is $host->{type}, 'string', $host->{name};
         is $port->{type}, 'string', $port->{name};
-        is $key->{type}, 'key', $key->{name};
+        is $key->{type}, 'enum', $key->{name};
+        is_deeply $key->{enum}, ['key', '""'], $key->{name};
         is $db->{type}, 'integer', $db->{name};
+        is $timeout->{type}, 'integer', $timeout->{name};
+        for my $arg (@extra) {
+            if ($arg->{command} eq 'KEYS') {
+                is $arg->{type}, 'key';
+            } else {
+                isnt $arg->{type}, 'key';
+            }
+        }
     }
 );
 


### PR DESCRIPTION
> m0t0k1ch1 [7:29 PM] 
> @shogo82148: 
> 
> ```
>     #   Failed test 'key'
>     #   at t/99_redis_doc.t line 117.
>     #          got: 'enum'
>     #     expected: 'key'
>     # Looks like you failed 1 test of 7.
> 
> #   Failed test 'MIGRATE'
> #   at t/99_redis_doc.t line 35.
> # Looks like you failed 1 test of 196.
> t/99_redis_doc.t ......
> ```
> 
> Yesterday at 7:10 PM
> 
> [7:30] 
> Redis::Namespace でテストがこけちゃってるので一応ご報告
> 
> [7:30] 
> https://github.com/antirez/redis-doc/commit/30714cc45a9fe2067650f5720c2a6e11e684d813#diff-e2571e1121887e3a7e1bf9d686e0ffce
> 
> [7:30] 
> 原因はこれっぽい