### PR TITLE
MIGRATE command is supported from 2.6.0

### DIFF
--- a/t/08_migrate.t
+++ b/t/08_migrate.t
@@ -27,6 +27,10 @@ my $ns1 = Redis::Namespace->new(redis => $redis1, namespace => 'ns');
 my $ns2 = Redis::Namespace->new(redis => $redis2, namespace => 'ns');
 
 subtest 'basic MIGRATE test' => sub {
+    my $redis_version = version->parse($redis1->info->{redis_version});
+    plan skip_all => 'your redis does not support MIGRATE command'
+        unless $redis_version >= '2.6.0';
+
     $redis1->flushall;
     $redis2->flushall;
     $ns1->set('hogehoge', 'foobar');


### PR DESCRIPTION
Redis 2.4.14 does not support MIGRATE command.

```
[migrate] ERR unknown command 'MIGRATE',  at /tmpfs/.cpan-build/2016011900/Redis-Namespace-0.07-UwE_Ao/blib/lib/Redis/Namespace.pm line 493.
    # Child (basic MIGRATE test) exited without calling finalize()
```

ref. http://www.cpantesters.org/cpan/report/5cf00dbe-be73-11e5-9d6b-e8e1fcd2507e
