### PR TITLE
Improve guess option

### DIFF
--- a/lib/Redis/Namespace.pm
+++ b/lib/Redis/Namespace.pm
@@ -613,7 +613,6 @@ sub _wrap_method {
     my ($class, $command) = @_;
     my ($cmd, @extra) = split /_/, lc($command);
     my $filters = $COMMANDS{$cmd};
-    my $warn_message;
     my ($before, $after);
     my @subcommand = ();
 
@@ -675,6 +674,11 @@ sub _wrap_method {
 
 sub _guess {
     my ($self, $command, @args) = @_;
+    if (!$self->{guess}) {
+        warn "Unknown command. Passing '$command' to the redis server as is.";
+        return $BEFORE_FILTERS{none}, $AFTER_FILTERS{none};
+    }
+
     if (my $cache = $self->{guess_cache}{$command}) {
         return @$cache;
     }
@@ -685,7 +689,7 @@ sub _guess {
     }
 
     my $info = $self->{redis}->command_info($command);
-    my ($name, $num, $flags, $first, $last, $step) = @{$info->[0]};
+    my ($name, $num, $flags, $first, $last, $step) = @{$info->[0] || []};
 
     unless ($name) {
         if ($self->{warning}) {

--- a/lib/Redis/Namespace.pm
+++ b/lib/Redis/Namespace.pm
@@ -596,14 +596,15 @@ sub new {
     $self->{warning} = $args{warning};
     $self->{subscribers} = {};
     if ($args{guess}) {
-        my $version = $self->{redis}->info->{redis_version};
-        my ($major, $minor, $rev) = split /\./, $version;
-        if ( $major >= 3 || $major == 2 && $minor >= 8 && $rev >= 13 ) {
+        my $count = eval { $self->{redis}->command_count };
+        if ($count) {
             $self->{guess} = 1;
         } elsif ($self->{warning}) {
+            my $version = $self->{redis}->info->{redis_version};
             warn "guess option requires 2.8.13 or later. your redis version is $version";
         }
     }
+    $self->{guess_cache} = {};
     return $self;
 }
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -427,11 +427,10 @@ subtest 'ZINTERSTORE/ZUNIONSTORE' => sub {
 };
 
 subtest 'GEORADIUS' => sub {
-    my $redis_version = version->parse($redis->info->{redis_version});
-    plan skip_all => 'your redis does not support GEO commands'
-        unless $redis_version >= '3.2.10';
-
-    $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
+    my $version = version->parse($redis->info->{redis_version});
+    eval {
+        $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
+    } or skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
 
     is_deeply([$ns->georadius(Sicily => 15, 37, 200, "km", "ASC")], ["Catania", "Palermo"], "GEORADIUS");
 
@@ -447,11 +446,10 @@ subtest 'GEORADIUS' => sub {
 };
 
 subtest 'GEORADIUSBYMEMBER' => sub {
-    my $redis_version = version->parse($redis->info->{redis_version});
-    plan skip_all => 'your redis does not support GEO commands'
-        unless $redis_version >= '3.2.10';
-
-    $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
+    my $version = version->parse($redis->info->{redis_version});
+    eval {
+        $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
+    } or skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
 
     is_deeply([$ns->georadiusbymember(Sicily => "Catania", 200, "km", "ASC")], ["Catania", "Palermo"], "GEORADIUS");
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -430,7 +430,7 @@ subtest 'GEORADIUS' => sub {
     my $version = version->parse($redis->info->{redis_version});
     eval {
         $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
-    } or skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
+    } or plan skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
 
     is_deeply([$ns->georadius(Sicily => 15, 37, 200, "km", "ASC")], ["Catania", "Palermo"], "GEORADIUS");
 
@@ -449,7 +449,7 @@ subtest 'GEORADIUSBYMEMBER' => sub {
     my $version = version->parse($redis->info->{redis_version});
     eval {
         $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
-    } or skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
+    } or plan skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
 
     is_deeply([$ns->georadiusbymember(Sicily => "Catania", 200, "km", "ASC")], ["Catania", "Palermo"], "GEORADIUS");
 

--- a/t/04_pipeline.t
+++ b/t/04_pipeline.t
@@ -11,7 +11,7 @@ eval { Test::RedisServer->new } or plan skip_all => 'redis-server is required in
 
 my $redis_server = Test::RedisServer->new;
 my $redis = Redis->new( $redis_server->connect_info );
-my $ns = Redis::Namespace->new(redis => $redis, namespace => 'ns');
+my $ns = Redis::Namespace->new(redis => $redis, namespace => 'ns', guess => 1, warning => 1);
 
 sub pipeline_ok {
     my ($desc, @commands) = @_;

--- a/t/97_subcommands.t
+++ b/t/97_subcommands.t
@@ -10,6 +10,8 @@ eval { Test::RedisServer->new } or plan skip_all => 'redis-server is required in
 
 my $redis_server = Test::RedisServer->new;
 my $redis = Redis->new( $redis_server->connect_info );
+eval { $redis->command_count } or plan skip_all => 'redis-server does not support the COMMAND command';
+
 my $ns = Redis::Namespace->new(redis => $redis, namespace => 'ns');
 
 subtest 'COMMAND COUNT' => sub {

--- a/t/98_guess.t
+++ b/t/98_guess.t
@@ -14,7 +14,7 @@ my $redis = Redis->new( $redis_server->connect_info );
 my $version = $redis->info->{redis_version};
 eval { $redis->command_count } or plan skip_all => "guess option requires the COMMAND command, but your redis server seems not to support it. your redis version is $version";
 
-my $ns = Redis::Namespace->new(redis => $redis, namespace => 'ns', guess => 1);
+my $ns = Redis::Namespace->new(redis => $redis, namespace => 'ns', guess => 1, warning => 1);
 
 subtest 'get and set' => sub {
     ok($ns->set(foo => 'bar'), 'set foo => bar');

--- a/t/98_guess.t
+++ b/t/98_guess.t
@@ -35,7 +35,7 @@ subtest 'GEORADIUS' => sub {
     my $version = version->parse($redis->info->{redis_version});
     eval {
         $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
-    } or skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
+    } or plan skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
 
     is_deeply([$ns->georadius(Sicily => 15, 37, 200, "km", "ASC")], ["Catania", "Palermo"], "GEORADIUS");
 

--- a/t/98_guess.t
+++ b/t/98_guess.t
@@ -6,16 +6,13 @@ use Test::RedisServer;
 eval { Test::RedisServer->new } or plan skip_all => 'redis-server is required in PATH to run this test';
 
 use Redis::Namespace;
-%Redis::Namespace::COMMANDS = ();
+%Redis::Namespace::COMMANDS = (); # clear commands list for test.
 
 my $redis_server = Test::RedisServer->new;
 my $redis = Redis->new( $redis_server->connect_info );
 
 my $version = $redis->info->{redis_version};
-my ($major, $minor, $rev) = split /\./, $version;
-unless ( $major >= 3 || $major == 2 && $minor >= 8 && $rev >= 13 ) {
-    plan skip_all => "guess option requires 2.8.13 or later. your redis version is $version";
-}
+eval { $redis->command_count } or plan skip_all => "guess option requires the COMMAND command, but your redis server seems not to support it. your redis version is $version";
 
 my $ns = Redis::Namespace->new(redis => $redis, namespace => 'ns', guess => 1);
 
@@ -31,6 +28,25 @@ subtest 'mget and mset' => sub {
     ok($ns->mset(foo => 'bar', hoge => 'fuga'), 'mset foo => bar, hoge => fuga');
     is_deeply([$ns->mget('foo', 'hoge')], ['bar', 'fuga'], 'mget foo hoge = hoge, fuga');
     is_deeply([$redis->mget('ns:foo', 'ns:hoge')], ['bar', 'fuga'], 'foo, hoge in namespace');
+    $redis->flushall;
+};
+
+subtest 'GEORADIUS' => sub {
+    my $version = version->parse($redis->info->{redis_version});
+    eval {
+        $redis->geoadd('ns:Sicily', 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania");
+    } or skip_all => "your redis server seems not to support GEO commands, your redis version is $version";
+
+    is_deeply([$ns->georadius(Sicily => 15, 37, 200, "km", "ASC")], ["Catania", "Palermo"], "GEORADIUS");
+
+    # STORE key
+    $ns->georadius(Sicily => 15, 37, 200, "km", STORE => "result");
+    is_deeply([$redis->zrange('ns:result', 0, -1)], ["Palermo", "Catania"]);
+
+    # STOREDIST key
+    $ns->georadius(Sicily => 15, 37, 200, "km", STOREDIST => "result");
+    is_deeply([$redis->zrange('ns:result', 0, -1)], ["Catania", "Palermo"]);
+
     $redis->flushall;
 };
 


### PR DESCRIPTION
Now Redis::Namespace can't guess key position of movablekeys commands such as GEORADIUS.
To resolve this, use [COMMAND GETKEYS](https://redis.io/commands/command-getkeys) helper command.
