### PR TITLE
drop support of Perl 5.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,7 @@ perl:
   - "5.26"
   - "5.24"
   - "5.22"
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
-dist: bionic
+dist: xenial
 env:
   - REDIS_VERSION=5.0.5
   - REDIS_VERSION=4.0.14
@@ -30,4 +24,3 @@ script:
   - redis-server --version
   - perl Build.PL
   - prove -lv t
-sudo: false

--- a/META.json
+++ b/META.json
@@ -47,7 +47,7 @@
       "runtime" : {
          "requires" : {
             "Redis" : "0",
-            "perl" : "5.010000"
+            "perl" : "5.022000"
          }
       },
       "test" : {

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.010000';
+requires 'perl', '5.022000';
 requires 'Redis';
 
 on 'test' => sub {


### PR DESCRIPTION
travis-ci dropped support of Perl 5.20, so it is hard for us to support Perl 5.20.

Xenial only supports 5.22, 5.24, 5.26, 5.28 and 5.30.
https://docs.travis-ci.com/user/reference/xenial/#perl-support
