### PR TITLE
Use trusty to test older Perls on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: perl
-perl:
-  - "5.30"
-  - "5.28"
-  - "5.26"
-  - "5.24"
-  - "5.22"
-dist: xenial
+matrix:
+  include:
+  - perl: "5.30"
+  - perl: "5.28"
+  - perl: "5.26"
+  - perl: "5.24"
+  - perl: "5.22"
+  - perl: "5.20"
+    dist: trusty
+  - perl: "5.18"
+    dist: trusty
+  - perl: "5.16"
+    dist: trusty
+  - perl: "5.14"
+    dist: trusty
+  - perl: "5.12"
+    dist: trusty
+  - perl: "5.10"
+    dist: trusty
 env:
   - REDIS_VERSION=5.0.5
   - REDIS_VERSION=4.0.14

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.022000';
+requires 'perl', '5.010001';
 requires 'Redis';
 
 on 'test' => sub {


### PR DESCRIPTION
Hopefully this helps you to support older Perls again. CPAN modules arbitrarily dropping support for Perls is unfortunate as it means things that depend on them also cannot support those Perls and so on...