### PR TITLE
Make xt/99_redis_doc.t more informative

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,4 +118,4 @@ jobs:
           cpanm --quiet --with-develop --installdeps --notest .
           cpanm --quiet Test::Perl::Critic
       - run: perl Build.PL
-      - run: prove -lv xt
+      - run: prove -lv xt 2>&1 

--- a/xt/99_redis_doc.t
+++ b/xt/99_redis_doc.t
@@ -87,7 +87,6 @@ our %before_tests = (
     },
     alternate => sub {
         for my $arg (@_) {
-            note explain $arg;
             is $arg->{type}[0], 'key', $arg->{name}[0];
             isnt $arg->{type}[1], 'key', $arg->{name}[1];
             is scalar @{$arg->{name}}, 2;
@@ -229,7 +228,7 @@ sub test_command {
                 ok my $suboption = $option->{$name}, "subcommand $name" or next;
                 my ($before, $after) = @$suboption;
                 $before //= 'none';
-                if (ok my $test = $before_tests{$before}, "subcommand $name, exists test for before fileter: $before") {
+                if (ok my $test = $before_tests{$before}, "subcommand $name, exists test for before filter: $before") {
                     my $names = $subcommand->{name};
                     if (ref $names eq 'ARRAY') {
                         $test->(
@@ -252,7 +251,7 @@ sub test_command {
         my ($before, $after) = @$option;
         $before //= 'none';
         ok $Redis::Namespace::BEFORE_FILTERS{$before}, "exists before filter: $before";
-        if (ok my $test = $before_tests{$before}, "exists test for before fileter: $before") {
+        if (ok my $test = $before_tests{$before}, "exists test for before filter: $before") {
             $test->(@{$info->{arguments}});
         }
         if ($after) {


### PR DESCRIPTION
I noticed that my last PR was failing author tests because of updates in redis's commands.json itself, so I tried to fix it, but never succeeded. I added a couple of changes to help debug it though:

* catch exceptions within a section and report it as partial failure;
* print out offending section on failure;
* print out summary about unknown commands/subcommands.